### PR TITLE
Require --environment with --organization

### DIFF
--- a/patterns/cli/services/lookup.py
+++ b/patterns/cli/services/lookup.py
@@ -50,6 +50,8 @@ class IdLookup:
     @cached_property
     def organization_id(self) -> str:
         if self.organization_name:
+            if not self.environment_name:
+                raise ValueError("Must --environment when you specify --organization")
             return get_organization_by_name(self.organization_name)["uid"]
         if self.cfg.organization_id:
             return self.cfg.organization_id

--- a/patterns/cli/services/lookup.py
+++ b/patterns/cli/services/lookup.py
@@ -51,7 +51,7 @@ class IdLookup:
     def organization_id(self) -> str:
         if self.organization_name:
             if not self.environment_name:
-                raise ValueError("Must --environment when you specify --organization")
+                raise ValueError("Must specify --environment when you specify --organization")
             return get_organization_by_name(self.organization_name)["uid"]
         if self.cfg.organization_id:
             return self.cfg.organization_id

--- a/patterns/cli/services/lookup.py
+++ b/patterns/cli/services/lookup.py
@@ -50,8 +50,6 @@ class IdLookup:
     @cached_property
     def organization_id(self) -> str:
         if self.organization_name:
-            if not self.environment_name:
-                raise ValueError("Must specify --environment when you specify --organization")
             return get_organization_by_name(self.organization_name)["uid"]
         if self.cfg.organization_id:
             return self.cfg.organization_id
@@ -72,6 +70,10 @@ class IdLookup:
 
     @cached_property
     def environment_id(self) -> str:
+        if self.organization_name and not self.environment_name:
+            raise ValueError(
+                "Must specify --environment when you specify --organization"
+            )
         if self.environment_name:
             env = get_environment_by_name(self.organization_id, self.environment_name)
             return env["uid"]


### PR DESCRIPTION
If you specify an `--organization`, we were previously using the configured environment id, but since this environment id doesn't exist in any other orgs, deployment would fail.