### PR TITLE
Update typer to 0.6

### DIFF
--- a/patterns/cli/main.py
+++ b/patterns/cli/main.py
@@ -1,8 +1,11 @@
+from types import MethodType
 from typing import List, Optional
 
 import click
 import typer
-from click import Group, Context, HelpFormatter, MultiCommand, Command
+from click import Context, MultiCommand, Command
+from typer import Typer
+from typer.core import TyperGroup
 
 from .commands.config import config
 from .commands.create import create
@@ -15,59 +18,14 @@ from .commands.trigger import trigger
 from .commands.upload import upload
 from ..cli.services import output
 
-
-class _Command(Group):
-    def __init__(self):
-        def debug_cb(ctx, p, v):
-            if v:
-                output.DEBUG = True
-
-        debug_opt = click.Option(
-            ["--stacktrace"], hidden=True, is_flag=True, callback=debug_cb
-        )
-        super().__init__(name="patterns", no_args_is_help=True, params=[debug_opt])
-
-    def add_typer_fn(self, fn, **kw):
-        if isinstance(fn, typer.Typer):
-            fn._add_completion = False
-            self.add_command(typer.main.get_command(fn))
-        else:
-            tmp = typer.Typer(add_completion=False)
-            tmp.command(**kw)(fn)
-            self.add_command(typer.main.get_command(tmp))
-
-    # override help output to include nested subcommands
-    def format_commands(self, ctx: Context, formatter: HelpFormatter) -> None:
-        old_list = self.list_commands
-        old_get = self.get_command
-
-        self.list_commands = self._list_commands
-        self.get_command = self._get_command
-
-        super().format_commands(ctx, formatter)
-
-        self.list_commands = old_list
-        self.get_command = old_get
-
-    def _list_commands(self, ctx: Context) -> List[str]:
-        l = super().list_commands(ctx)
-        for c in l:
-            sub = super().get_command(ctx, c)
-            if isinstance(sub, MultiCommand):
-                l.extend(f"{c} {s}" for s in sub.list_commands(ctx))
-        return l
-
-    def _get_command(self, ctx: Context, cmd_name: str) -> Optional[Command]:
-        parts = cmd_name.split()
-        base = super().get_command(ctx, parts[0])
-        if len(parts) == 1:
-            return base
-        assert len(parts) == 2
-        assert isinstance(base, MultiCommand)
-        return base.get_command(ctx, parts[1])
+app = Typer(name="patterns", no_args_is_help=True, add_completion=False)
 
 
-app = _Command()
+@app.callback()
+def cb(stacktrace: bool = typer.Option(False, hidden=True)):
+    if stacktrace:
+        output.DEBUG = True
+
 
 for command in (
     config,
@@ -81,8 +39,59 @@ for command in (
     pull,
     clone,
 ):
-    app.add_typer_fn(command)
+    if isinstance(command, typer.Typer):
+        command._add_completion = False
+        app.add_typer(command)
+    else:
+        app.command()(command)
 
 
 def main():
+    def _get_group(*args, **kwargs) -> click.Command:
+        group = _old_typer_get_group(*args, **kwargs)
+
+        def _list_commands(self, ctx: Context) -> List[str]:
+            l = super(TyperGroup, self).list_commands(ctx)
+            for c in l:
+                sub = super(TyperGroup, self).get_command(ctx, c)
+                if isinstance(sub, MultiCommand):
+                    l.extend(f"{c} {s}" for s in sub.list_commands(ctx))
+            return l
+
+        def _get_command(self, ctx: Context, cmd_name: str) -> Optional[Command]:
+            parts = cmd_name.split()
+            base = super(TyperGroup, self).get_command(ctx, parts[0])
+            if len(parts) == 1:
+                return base
+            assert len(parts) == 2
+            assert isinstance(base, MultiCommand)
+            cmd = base.get_command(ctx, parts[1])
+            cmd.name = cmd_name
+            return cmd
+
+        def format_help(
+            self, ctx: click.Context, formatter: click.HelpFormatter
+        ) -> None:
+            old_list = self.list_commands
+            old_get = self.get_command
+
+            self.list_commands = MethodType(_list_commands, self)
+            self.get_command = MethodType(_get_command, self)
+
+            typer.core.rich_utils.rich_format_help(
+                obj=self,
+                ctx=ctx,
+                markup_mode=self.rich_markup_mode,
+            )
+
+            self.list_commands = old_list
+            self.get_command = old_get
+
+        group.format_help = MethodType(format_help, group)
+
+        return group
+
+    _old_typer_get_group = typer.main.get_group
+    typer.main.get_group = _get_group
     app()
+    typer.main.get_group = _old_typer_get_group

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.8"
 rich = "^12.0.1"
 ruyaml = "^0.91.0"
 click = "^8.1.0"
-typer = {extras = ["all"], version = "^0.4.1"}
+typer = {extras = ["all"], version = "^0.6.1"}
 PyYAML = "^6.0"
 requests = "^2.27.1"
 

--- a/tests/cli/base.py
+++ b/tests/cli/base.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 import requests_mock
+import typer.testing
 from click.testing import Result
 
 from patterns.cli.config import DEVKIT_CONFIG_ENV_VAR, update_devkit_config
@@ -16,7 +17,7 @@ from patterns.cli.services.api import API_BASE_URL, Endpoints, build_url
 
 def run_cli(argv: str, input: str = None, **kwargs) -> click.testing.Result:
     args = ["--stacktrace"] + shlex.split(argv.replace("\\", "/"))
-    runner = click.testing.CliRunner()
+    runner = typer.testing.CliRunner()
     result = runner.invoke(app, args, input, catch_exceptions=False, **kwargs)
     print(result.output)
     return result


### PR DESCRIPTION
The latest version of typer stopped using Click's help formatting code in favor of its own implementation. It's not customizable at all, so in order to support showing subcommands in help, I had to do some pretty serious monkey patching.