### PR TITLE
Upload improvements: support binary files in diff, add default ignore list

### DIFF
--- a/tests/cli/test_diffs.py
+++ b/tests/cli/test_diffs.py
@@ -1,0 +1,51 @@
+import io
+from pathlib import Path
+from zipfile import ZipFile
+
+from patterns.cli.services.diffs import get_diffs_between_zip_and_dir
+
+
+def test_diffs(tmp_path: Path):
+    txt = tmp_path / "t.txt"
+    txt2 = tmp_path / "t2.txt"
+    bin = tmp_path / "b.bin"
+    txt.write_text("foo\nbar\nbaz")
+    txt2.write_text("foo\nbar\nbaz")
+    bin.write_bytes(b"\xf1\xf2\xf3")
+    zfbytes = io.BytesIO()
+    with ZipFile(zfbytes, "w") as zf:
+        zf.write(txt, "t.txt")
+        zf.write(txt2, "t2.txt")
+        zf.write(bin, "b.bin")
+
+        diffs = get_diffs_between_zip_and_dir(zf, tmp_path)
+        assert diffs.added == []
+        assert diffs.removed == []
+        assert diffs.changed == {}
+
+        txt2.unlink()
+        (tmp_path / "t3.txt").write_text("t3")
+        txt.write_text("foo\nbar2\nbaz\nqux")
+        bin.write_bytes(b"\xf1\xff")
+
+        diffs = get_diffs_between_zip_and_dir(zf, tmp_path)
+        assert diffs.added == ["t3.txt"]
+        assert diffs.removed == ["t2.txt"]
+        changed = {k: list(v) for k, v in diffs.changed.items()}
+        assert changed == {
+            "b.bin": [
+                "--- <remote> b.bin",
+                "+++ <local>  b.bin",
+                "Binary contents differ",
+            ],
+            "t.txt": [
+                "--- <remote> t.txt",
+                "+++ <local>  t.txt",
+                "@@ -1,3 +1,4 @@",
+                " foo",
+                "-bar",
+                "+bar2",
+                " baz",
+                "+qux",
+            ],
+        }

--- a/tests/cli/test_file_ignore.py
+++ b/tests/cli/test_file_ignore.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from patterns.cli.helpers import _all_files_not_ignored
+
+
+def test_ignore_file(tmp_path: Path):
+    f1 = tmp_path / "__pycache__" / "settings.xml"
+    f1.parent.mkdir()
+    f1.write_text("<>")
+
+    f2 = tmp_path / ".DS_Store" / "foo"
+    f2.parent.mkdir()
+    f2.write_text("foo")
+
+    f3 = tmp_path / "my.venv" / "foo.txt"
+    f3.parent.mkdir()
+    f3.write_text("foo")
+
+    f4 = tmp_path / "p.pyc"
+    f4.write_text("foo")
+
+    f5 = tmp_path / "my.pycx"
+    f5.write_text("foo")
+
+    assert sorted(_all_files_not_ignored(tmp_path)) == sorted([f3, f5])


### PR DESCRIPTION
- Handle binary files when computing diffs.
- When uploading an app that doesn't have it's own .gitignore file, we now have a default list of files to ignore.