### PR TITLE
Improve various help outputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,0 @@
-[mypy]
-ignore_missing_imports = True
-check_untyped_defs = True
-ignore_errors = False
-strict_optional = True
-warn_redundant_casts = True
-warn_unused_configs = True

--- a/patterns/cli/commands/create.py
+++ b/patterns/cli/commands/create.py
@@ -24,7 +24,7 @@ def app(
     name: str = Option("", "--name", "-n", help=_name_help),
     location: Path = Argument(None, metavar="APP"),
 ):
-    """Add a new node to an app"""
+    """Create a new empty app"""
     if not location:
         prompt = "Enter a name for the new app directory [prompt.default](e.g. my-app)"
         location = prompt_path(prompt, exists=False)

--- a/patterns/cli/commands/create.py
+++ b/patterns/cli/commands/create.py
@@ -132,7 +132,7 @@ def webhook(
     )
 
 
-_organization_help = "The name of the Patterns organization to add a secret to"
+_organization_help = "The Patterns organization to add a secret to"
 _secret_name_help = (
     "The name of the secret. Can only contain letters, numbers, and underscores."
 )
@@ -143,7 +143,9 @@ _sensitive_help = "Mark the secret value as sensitive. This value won't be visib
 
 @create.command()
 def secret(
-    organization: str = Option("", "-o", "--organization", help=_organization_help),
+    organization: str = Option(
+        "", "-o", "--organization", metavar="SLUG", help=_organization_help
+    ),
     sensitive: bool = Option(False, "--sensitive", "-s", help=_sensitive_help),
     description: str = Option(None, "-d", "--description", help=_secret_desc_help),
     name: str = Argument(..., help=_webhook_name_help),

--- a/patterns/cli/commands/delete.py
+++ b/patterns/cli/commands/delete.py
@@ -7,12 +7,14 @@ from patterns.cli.services.lookup import IdLookup
 from patterns.cli.services.output import sprint, abort_on_error
 
 _force_help = "Don't prompt before deleting an app"
-_organization_help = "The name of the Patterns organization to delete from"
+_organization_help = "The Patterns organization to delete from"
 
 
 def delete(
     force: bool = Option(False, "-f", "--force", help=_force_help),
-    organization: str = Option("", "-o", "--organization", help=_organization_help),
+    organization: str = Option(
+        "", "-o", "--organization", metavar="SLUG", help=_organization_help
+    ),
     app: str = app_argument,
 ):
     """Delete an app from the Patterns studio.

--- a/patterns/cli/commands/download.py
+++ b/patterns/cli/commands/download.py
@@ -14,13 +14,15 @@ from patterns.cli.services.lookup import IdLookup
 from patterns.cli.services.output import sprint, abort_on_error
 
 _directory_help = "The directory to download the app to"
-_organization_help = "The name of the Patterns organization that the graph belongs to"
+_organization_help = "The Patterns organization that the graph belongs to"
 _force_help = "Overwrite existing files without prompting"
 _diff_help = "Show a full diff of file conflicts"
 
 
 def download(
-    organization: str = Option("", "-o", "--organization", help=_organization_help),
+    organization: str = Option(
+        "", "-o", "--organization", metavar="SLUG", help=_organization_help
+    ),
     force: bool = Option(False, "-f", "--force", help=_force_help),
     diff: bool = Option(False, "-d", "--diff", help=_diff_help),
     app: str = app_argument,

--- a/patterns/cli/commands/list.py
+++ b/patterns/cli/commands/list.py
@@ -31,7 +31,10 @@ def apps(
     ids = IdLookup(organization_slug=organization)
     with abort_on_error("Error listing apps"):
         gs = list(paginated_graphs(ids.organization_uid))
-    _print_objects("apps", gs, print_json)
+        for g in gs:
+            g.pop("organization_uid", None)  # all graphs are for the current org
+            g.pop("updated_at", None)  # not very useful; leave space for the ui_url
+    _print_objects("apps", gs, print_json, ("title", "slug", "uid"))
 
 
 @list_command.command()

--- a/patterns/cli/commands/list.py
+++ b/patterns/cli/commands/list.py
@@ -15,9 +15,11 @@ from patterns.cli.services.webhooks import paginated_webhooks
 
 _type_help = "The type of object to list"
 _json_help = "Output the object as JSON Lines"
-_organization_help = "The name of the Patterns organization to use"
+_organization_help = "The Patterns organization to use"
 
-_organization_option = Option("", "--organization", "-o", help=_organization_help)
+_organization_option = Option(
+    "", "--organization", "-o", metavar="SLUG", help=_organization_help
+)
 
 list_command = typer.Typer(name="list", help="List objects of a given type")
 

--- a/patterns/cli/commands/login.py
+++ b/patterns/cli/commands/login.py
@@ -1,3 +1,5 @@
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
 from patterns.cli.config import (
     update_devkit_config,
     get_devkit_config_path,
@@ -6,7 +8,7 @@ from patterns.cli.services import login as login_service
 from patterns.cli.services.accounts import me
 from patterns.cli.services.api import reset_session_auth
 from patterns.cli.services.lookup import IdLookup
-from patterns.cli.services.output import sprint, abort_on_error
+from patterns.cli.services.output import sprint, abort_on_error, console
 
 
 def login():
@@ -14,10 +16,23 @@ def login():
     reset_session_auth()
 
     with abort_on_error("Login failed"):
-        login_service.login()
+        sprint("[info]Logging in to Patterns...")
+        url, login_config = login_service.make_login_config()
+        sprint(f"[info]Opening url:")
+        sprint(url)
+
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("Waiting for authorization..."),
+            console=console,
+            transient=True,
+        )
+        with progress:
+            progress.add_task("")
+            login_service.login(url, login_config)
 
     ids = IdLookup(ignore_local_cfg=True)
-    with abort_on_error("Fetching account failed"):
+    with abort_on_error("Saving authorization token failed"):
         update_devkit_config(organization_id=ids.organization_uid)
 
     with abort_on_error("Fetching user profile failed"):

--- a/patterns/cli/commands/logout.py
+++ b/patterns/cli/commands/logout.py
@@ -1,10 +1,8 @@
 from patterns.cli.services import logout as logout_service
 from patterns.cli.services.api import reset_session_auth
-from patterns.cli.services.output import sprint
 
 
 def logout():
     """Log out of your Patterns account"""
     reset_session_auth()
     logout_service.logout()
-    sprint("[success]Logged out")

--- a/patterns/cli/commands/trigger.py
+++ b/patterns/cli/commands/trigger.py
@@ -16,7 +16,9 @@ _node_help = "The path to the node to trigger"
 
 
 def trigger(
-    organization: str = Option("", "-o", "--organization", help=_organization_help),
+    organization: str = Option(
+        "", "-o", "--organization", metavar="SLUG", help=_organization_help
+    ),
     app: str = Option(None, exists=True, help=app_argument_help),
     type: str = Option("pubsub", hidden=True),
     node_id: str = Option(None, help=_node_id_help),

--- a/patterns/cli/commands/update.py
+++ b/patterns/cli/commands/update.py
@@ -11,7 +11,7 @@ from patterns.cli.services.output import sprint, abort_on_error
 
 _organization_help = "The name of the Patterns organization to use"
 _public_help = "Set the app to public or private. Public apps may be viewed by anyone."
-_deprecated_help = "Set the app's component as deprecated or not. Deprecated apps cannot be added to new apps, but continue to function if existing apps use them"
+_deprecated_help = "Set the app's component as deprecated or not. Deprecated components cannot be added to new apps, but continue to function if existing apps use them"
 _organization_option = Option("", "--organization", "-o", help=_organization_help)
 
 update_command = typer.Typer(name="update", help="Update an object of a given type")

--- a/patterns/cli/commands/update.py
+++ b/patterns/cli/commands/update.py
@@ -12,14 +12,16 @@ from patterns.cli.services.output import sprint, abort_on_error
 _organization_help = "The name of the Patterns organization to use"
 _public_help = "Set the app to public or private. Public apps may be viewed by anyone."
 _deprecated_help = "Set the app's component as deprecated or not. Deprecated components cannot be added to new apps, but continue to function if existing apps use them"
-_organization_option = Option("", "--organization", "-o", help=_organization_help)
+_organization_option = Option(
+    "", "--organization", "-o", metavar="SLUG", help=_organization_help
+)
 
 update_command = typer.Typer(name="update", help="Update an object of a given type")
 
 
 @update_command.command()
 def app(
-    organization: str = Option("", help=_organization_help),
+    organization: str = _organization_option,
     public: Optional[bool] = Option(
         None, "--public/--private", show_default=False, help=_public_help
     ),

--- a/patterns/cli/commands/update.py
+++ b/patterns/cli/commands/update.py
@@ -9,7 +9,7 @@ from patterns.cli.services.graph_versions import update_graph
 from patterns.cli.services.lookup import IdLookup
 from patterns.cli.services.output import sprint, abort_on_error
 
-_organization_help = "The name of the Patterns organization to use"
+_organization_help = "The Patterns organization that the app belongs to"
 _public_help = "Set the app to public or private. Public apps may be viewed by anyone."
 _deprecated_help = "Set the app's component as deprecated or not. Deprecated components cannot be added to new apps, but continue to function if existing apps use them"
 _organization_option = Option(

--- a/patterns/cli/commands/upload.py
+++ b/patterns/cli/commands/upload.py
@@ -15,14 +15,16 @@ from patterns.cli.services.output import sprint, abort_on_error
 from patterns.cli.services.upload import upload_graph_version
 
 _app_help = "The location of the graph.yml file of the app to upload"
-_organization_help = "The name of the Patterns organization to upload to"
+_organization_help = "The Patterns organization to upload to"
 _component_help = "After uploading, publish the app version as a public component"
 _force_help = "Overwrite existing files without prompting"
 _diff_help = "Show a full diff of file conflicts"
 
 
 def upload(
-    organization: str = Option("", "-o", "--organization", help=_organization_help),
+    organization: str = Option(
+        "", "-o", "--organization", metavar="SLUG", help=_organization_help
+    ),
     force: bool = Option(False, "-f", "--force", help=_force_help),
     diff: bool = Option(False, "-d", "--diff", help=_diff_help),
     publish_component: bool = Option(False, help=_component_help),

--- a/patterns/cli/configuration/edit.py
+++ b/patterns/cli/configuration/edit.py
@@ -101,13 +101,12 @@ class GraphConfigEditor:
     def add_node(
         self,
         node_file: str,
-        schedule: str = None,
+        trigger: str = None,
         inputs: Dict[str, str] = None,
         outputs: Dict[str, str] = None,
         parameters: Dict[str, Any] = None,
         title: str = None,
         id: Optional[str] = MISSING,
-        description: str = None,
         description_file: str = None,
     ) -> GraphConfigEditor:
         if id is MISSING:
@@ -115,13 +114,12 @@ class GraphConfigEditor:
         self.add_function_node_dict(
             {
                 "node_file": node_file,
-                "schedule": schedule,
+                "trigger": trigger,
                 "inputs": inputs,
                 "outputs": outputs,
                 "parameters": parameters,
                 "title": title,
                 "id": str(id) if id else id,
-                "description": description,
                 "description_file": description_file,
             }
         )
@@ -130,16 +128,13 @@ class GraphConfigEditor:
     def add_store(
         self,
         name: str,
-        table: bool,
-        title: str = None,
         id: Optional[str] = MISSING,
         schema: str = None,
     ):
         if id is MISSING:
             id = random_node_id()
         d = {
-            "table" if table else "stream": name,
-            "title": title,
+            "table": name,
             "id": str(id) if id else id,
             "schema": schema,
         }
@@ -163,7 +158,6 @@ class GraphConfigEditor:
         webhook: str,
         title: str = None,
         id: Optional[str] = MISSING,
-        description: str = None,
         description_file: str = None,
     ) -> GraphConfigEditor:
         if id is MISSING:
@@ -173,7 +167,6 @@ class GraphConfigEditor:
                 "webhook": webhook,
                 "title": title,
                 "id": str(id) if id else id,
-                "description": description,
                 "description_file": description_file,
             }
         )
@@ -182,13 +175,12 @@ class GraphConfigEditor:
     def add_component_uses(
         self,
         component_key: str,
-        schedule: str = None,
+        trigger: str = None,
         inputs: Dict[str, str] = None,
         outputs: Dict[str, str] = None,
         parameters: Dict[str, Any] = None,
         title: str = None,
         id: Optional[str] = MISSING,
-        description: str = None,
         description_file: str = None,
     ) -> GraphConfigEditor:
         if id is MISSING:
@@ -196,13 +188,12 @@ class GraphConfigEditor:
         self.add_function_node_dict(
             {
                 "uses": component_key,
-                "schedule": schedule,
+                "trigger": trigger,
                 "inputs": inputs,
                 "outputs": outputs,
                 "parameters": parameters,
                 "title": title,
                 "id": str(id) if id else id,
-                "description": description,
                 "description_file": description_file,
             }
         )

--- a/patterns/cli/main.py
+++ b/patterns/cli/main.py
@@ -48,7 +48,12 @@ def version_cb(value: bool):
     raise typer.Exit()
 
 
-@app.callback()
+@app.callback(
+    help=f"""[cyan]Patterns Devkit {__version__} 
+    
+    [not dim][green]Read the docs:[/] https://www.patterns.app/docs/devkit
+    """
+)
 def cb(
     stacktrace: bool = typer.Option(False, hidden=True),
     _: bool = typer.Option(

--- a/patterns/cli/services/auth.py
+++ b/patterns/cli/services/auth.py
@@ -59,7 +59,7 @@ def execute_oauth_flow(
     if server.error_result:
         abort(server.error_result)
     elif server.success_result:
-        sprint(f"[info]{server.success_result}")
+        sprint(f"[success]{server.success_result}\n")
     else:
         abort("OAuth server finished without an error or success result")
 

--- a/patterns/cli/services/diffs.py
+++ b/patterns/cli/services/diffs.py
@@ -1,5 +1,4 @@
 import difflib
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, List, Dict
@@ -7,6 +6,7 @@ from zipfile import ZipFile
 
 from rich.markdown import Markdown
 
+from patterns.cli.helpers import directory_contents_to_upload
 from patterns.cli.services.output import sprint
 
 
@@ -58,11 +58,10 @@ def get_diffs_between_zip_and_dir(zf: ZipFile, root: Path) -> DiffResult:
                     lineterm="",
                 )
                 result.changed[zipinfo.filename] = diff
-    for base, _, names in os.walk(root):
-        for name in names:
-            fname = (Path(base) / name).relative_to(root).as_posix()
-            if fname not in all_in_zip:
-                result.added.append(fname)
+    for path in directory_contents_to_upload(root):
+        file_name = path.relative_to(root).as_posix()
+        if file_name not in all_in_zip:
+            result.added.append(file_name)
 
     return result
 

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -64,11 +64,27 @@ def test_create_node_invalid_py_name(tmp_path: Path):
 def test_create_webhook(tmp_path: Path):
     dr = set_tmp_dir(tmp_path).parent / "graph"
     run_cli("create app", f"{dr}\n")
+    run_cli(f"create node --app={dr} --type=webhook hook")
+    text = (dr / "graph.yml").read_text()
+    assert "webhook: hook" in text
+    assert "table: hook" in text
+
+
+def test_create_component(tmp_path: Path):
+    dr = set_tmp_dir(tmp_path).parent / "graph"
+    run_cli("create app", f"{dr}\n")
+    run_cli(f"create node --type=component --app={dr} foo/bar@v1")
+    assert f"uses: foo/bar@v1" in (dr / "graph.yml").read_text()
+
+
+def test_create_webhook_deprecated(tmp_path: Path):
+    dr = set_tmp_dir(tmp_path).parent / "graph"
+    run_cli("create app", f"{dr}\n")
     run_cli(f"create webhook --app={dr} hook")
     assert f"webhook: hook" in (dr / "graph.yml").read_text()
 
 
-def test_create_component(tmp_path: Path):
+def test_create_component_deprecated(tmp_path: Path):
     dr = set_tmp_dir(tmp_path).parent / "graph"
     run_cli("create app", f"{dr}\n")
     run_cli(f"create node --component=foo/bar@v1", f"{dr}\n")

--- a/tests/configuration/test_config_editor.py
+++ b/tests/configuration/test_config_editor.py
@@ -66,10 +66,10 @@ def test_add_webhook_with_all_fields(tmp_path: Path):
       - webhook: hook
         title: n
         id: ab234567
-        description: desc
+        description_file: desc.md
     """
     get_editor(tmp_path, before).add_webhook(
-        "hook", "n", "ab234567", "desc"
+        "hook", "n", "ab234567", "desc.md"
     ).assert_dump(after)
 
 
@@ -80,14 +80,13 @@ def test_add_store_with_all_fields(tmp_path: Path):
     after = """
     title: graph
     stores:
-      - stream: st
-        title: n
+      - table: st
         id: ab234567
         schema: sc
     """
-    get_editor(tmp_path, before).add_store(
-        "st", False, "n", "ab234567", "sc"
-    ).assert_dump(after)
+    get_editor(tmp_path, before).add_store("st", "ab234567", "sc").assert_dump(
+        after
+    )
 
 
 def test_add_node_with_all_fields(tmp_path: Path):
@@ -101,7 +100,7 @@ def test_add_node_with_all_fields(tmp_path: Path):
     functions:
       - webhook: hook
       - node_file: node.py
-        schedule: daily
+        trigger: 1 * * * *
         inputs:
           node_in: hook
         outputs:
@@ -110,17 +109,15 @@ def test_add_node_with_all_fields(tmp_path: Path):
           limit: 2
         title: my node
         id: ab234567
-        description: desc
     """
     get_editor(tmp_path, before).add_node(
         "node.py",
-        schedule="daily",
+        trigger="1 * * * *",
         inputs={"node_in": "hook"},
         outputs={"node_out": "my_table"},
         parameters={"limit": 2},
         title="my node",
         id="ab234567",
-        description="desc",
     ).assert_dump(after)
 
 
@@ -135,7 +132,7 @@ def test_add_component_with_all_fields(tmp_path: Path):
       functions:
         - webhook: hook
         - uses: org/component@v1
-          schedule: daily
+          trigger: 1 * * * *
           inputs:
             node_in: hook
           outputs:
@@ -144,17 +141,15 @@ def test_add_component_with_all_fields(tmp_path: Path):
             limit: 2
           title: my node
           id: ab234567
-          description: desc
       """
     get_editor(tmp_path, before).add_component_uses(
         "org/component@v1",
-        schedule="daily",
+        trigger="1 * * * *",
         inputs={"node_in": "hook"},
         outputs={"node_out": "my_table"},
         parameters={"limit": 2},
         title="my node",
         id="ab234567",
-        description="desc",
     ).assert_dump(after)
 
 


### PR DESCRIPTION
- Many small typo fixes and help improvements
- Unify the three different way to add a node into a single command `add node --type=`. The `add webhook` and `add node --component` methods are kept for backwards compatibility, but are hidden from help.
- Add a connected table when adding a webhook if the table doesn't already exist
- Omit .gitignored files from diffs
- Allow ctrl-c to kill the `login` and `logout` commands
- Update the `GraphDirectoryEditor` to the latest yaml format