### PR TITLE
Show diff reversed when downloading

### DIFF
--- a/patterns/cli/commands/download.py
+++ b/patterns/cli/commands/download.py
@@ -59,7 +59,7 @@ def download(
             if force:
                 zf.extractall(root)
             else:
-                conflicts = get_diffs_between_zip_and_dir(zf, root)
+                conflicts = get_diffs_between_zip_and_dir(zf, root, True)
                 if not conflicts.changed:
                     zf.extractall(root)
                     sprint(f"[success]Downloaded app {ids.graph_slug}")

--- a/patterns/cli/commands/upload.py
+++ b/patterns/cli/commands/upload.py
@@ -48,7 +48,9 @@ def upload(
             pass
         else:
             with ZipFile(content, "r") as zf:
-                conflicts = get_diffs_between_zip_and_dir(zf, ids.graph_directory)
+                conflicts = get_diffs_between_zip_and_dir(
+                    zf, ids.graph_directory, False
+                )
                 if conflicts.is_not_empty:
                     sprint("[info]Upload would change the following files:\n")
                     print_diffs(conflicts, diff, True)

--- a/tests/cli/test_diffs.py
+++ b/tests/cli/test_diffs.py
@@ -18,7 +18,7 @@ def test_diffs(tmp_path: Path):
         zf.write(txt2, "t2.txt")
         zf.write(bin, "b.bin")
 
-        diffs = get_diffs_between_zip_and_dir(zf, tmp_path)
+        diffs = get_diffs_between_zip_and_dir(zf, tmp_path, False)
         assert diffs.added == []
         assert diffs.removed == []
         assert diffs.changed == {}
@@ -28,7 +28,7 @@ def test_diffs(tmp_path: Path):
         txt.write_text("foo\nbar2\nbaz\nqux")
         bin.write_bytes(b"\xf1\xff")
 
-        diffs = get_diffs_between_zip_and_dir(zf, tmp_path)
+        diffs = get_diffs_between_zip_and_dir(zf, tmp_path, False)
         assert diffs.added == ["t3.txt"]
         assert diffs.removed == ["t2.txt"]
         changed = {k: list(v) for k, v in diffs.changed.items()}
@@ -47,5 +47,27 @@ def test_diffs(tmp_path: Path):
                 "+bar2",
                 " baz",
                 "+qux",
+            ],
+        }
+
+        diffs = get_diffs_between_zip_and_dir(zf, tmp_path, True)
+        assert diffs.added == ["t2.txt"]
+        assert diffs.removed == ["t3.txt"]
+        changed = {k: list(v) for k, v in diffs.changed.items()}
+        assert changed == {
+            "b.bin": [
+                "--- <remote> b.bin",
+                "+++ <local>  b.bin",
+                "Binary contents differ",
+            ],
+            "t.txt": [
+                "--- <remote> t.txt",
+                "+++ <local>  t.txt",
+                "@@ -1,4 +1,3 @@",
+                " foo",
+                "-bar2",
+                "+bar",
+                " baz",
+                "-qux",
             ],
         }


### PR DESCRIPTION
Now e.g. files that exist on the remote but not locally will show as added for `download` and deleted for `upload`.